### PR TITLE
Switch CI from CircleCI/Docker Hub to GitHub Actions/GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 __pycache__
 .*cache
 .circleci
+.github
 .claude
 .coverage*
 .DS_Store

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,50 @@
+name: Build & Push Docker Image
+on:
+  push:
+    branches:
+      - develop
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load .env
+        run: |
+          set -a
+          source .env
+          echo "PLATFORMS=$PLATFORMS" >> "$GITHUB_ENV"
+          echo "BASE_VERSION=$BASE_VERSION" >> "$GITHUB_ENV"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "REPO=$REPO" >> "$GITHUB_ENV"
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ env.PLATFORMS }}
+          build-args: |
+            BASE_VERSION=${{ env.BASE_VERSION }}
+            VERSION=${{ env.VERSION }}
+          tags: |
+            ghcr.io/${{ env.REPO }}:${{ env.VERSION }}
+            ghcr.io/${{ env.REPO }}:latest
+          push: ${{ github.ref == 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ variables. If omitted, these variables the `CMD` runs as root.
 
 ## Docker Image
 
-[ajslater/python-debian](https://hub.docker.com/repository/docker/ajslater/python-debian)
+[ghcr.io/ajslater/python-debian](https://github.com/ajslater/python-debian/pkgs/container/python-debian)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   python-debian:
-    image: ajslater/python-debian
+    image: ghcr.io/ajslater/python-debian
     build:
       context: .
       args:


### PR DESCRIPTION
## Changes

- **CI/CD Pipeline**: Migrate from CircleCI to GitHub Actions with new workflow file (`.github/workflows/build.yaml`)
- **Container Registry**: Switch from Docker Hub to GitHub Container Registry (GHCR)
- **Image References**: Update all image references from `ajslater/python-debian` to `ghcr.io/ajslater/python-debian`
- **Docker Configuration**: Add `.github` directory to `.dockerignore`
- **Documentation**: Update README with new GHCR image link
- **Compose File**: Update `compose.yaml` to use new GHCR image location

## Workflow Details

The new GitHub Actions workflow:
- Triggers on push to `develop` and `main` branches
- Sets up multi-platform builds with QEMU
- Authenticates with GHCR using GitHub token
- Builds and pushes to GHCR (only on `main` branch)
- Tags images with version and `latest` tags